### PR TITLE
FIX: Фикс функции нахождения ближайшей ноды

### DIFF
--- a/receiver-processor-microcontroller/receiver-processor-microcontroller.ino
+++ b/receiver-processor-microcontroller/receiver-processor-microcontroller.ino
@@ -103,11 +103,11 @@ void loop() {
  *  @return ближайший узел */
 int findNearestNode(float lat1, float lng1){
   int minIndex = 0;
-  float minDiff = 999999.0;
+  float minDiff = 9999999;
   for(int i=0; i<SIZE; i++){
-    float lat_diff = lat1 - ARR_LAT[i];
-    float lng_diff = lng1 - ARR_LNG[i];
-    float diff = sqrt(lat_diff*lat_diff + lng_diff*lng_diff);
+    float diff = fabs(lat1 - pgm_read_float_near(ARR_LAT + i)) + 
+                 fabs(lng1 - pgm_read_float_near(ARR_LNG + i));
+                 
     if(diff < minDiff){
       minIndex = i;
       minDiff = diff;


### PR DESCRIPTION
Проблема была в способе считывания массива из программной памяти (`PROGMEM`).
+ для отладки переносил код на `CMake Version 3.13`, по итогу сопоставил входные аргументы и возвращаемые значения на обеих платформах.